### PR TITLE
Updated source files to support status code check on failing tests

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,5 +1,30 @@
 #! /bin/bash
 
+status_code=0
+log_file='extractReport_status.log'
+status_message='Android Test Report Action executed successfully.'
+
+echo ''
+echo '------------------------------------------------'
+echo '---        Android Test Report Action        ---'
+echo '------------------------------------------------'
+echo ''
+echo ''
+
+touch $log_file
+
 for i in `find . -name "TEST-*.xml" -type f`; do
     python extractReport.py "$i"
+    echo ''
 done
+
+if grep -q 'error' "$log_file"; then
+  status_code=1
+  status_message='There were failing tests. Android Test Report Action failed the job.'
+fi
+
+rm $log_file
+
+echo $status_message
+echo ''
+exit $status_code

--- a/extractReport.py
+++ b/extractReport.py
@@ -9,6 +9,10 @@ def parseXML(xmlfile):
         cs = len(k)
         sp = 16-cs
         print(k.capitalize() + " "*sp + v)
+        if ((k == "failures") and (int(v) > 0)) or ((k == "errors") and (int(v) > 0)):
+            f = open("extractReport_status.log", "w")
+            f.write("error")
+            f.close()
     print("")
 
 def main():


### PR DESCRIPTION
Added status code checker. If the report contain a failing test result, the job will display all of the report as well as fail the job.