### PR TITLE
Include to report only failed tests - parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Android Test Report Action
 
+[![Release](https://img.shields.io/github/release/asadmansr/android-test-report-action.svg)](https://github.com/asadmansr/android-test-report-action/releases)
+[![Marketplace](https://img.shields.io/badge/GitHub-Marketplace-orange.svg)](https://github.com/marketplace/actions/android-test-report-action)
+
 GitHub Action that prints Android test xml reports.
 
 ![action](./images/promo.png)
@@ -43,7 +46,7 @@ jobs:
         run: ./gradlew testDebugUnitTest
 
       - name: Android Test Report
-        uses: devapro/android-test-report-action@v1.3
+        uses: asadmansr/android-test-report-action@v1.2.0
         with:
           onlyFailed: true
         if: ${{ always() }} # IMPORTANT: run Android Test Report regardless
@@ -86,7 +89,7 @@ jobs:
           name: reports
 
       - name: Android Test Report
-        uses: devapro/android-test-report-action@v1.3
+        uses: asadmansr/android-test-report-action@v1.2.0
         with:
           onlyFailed: true
 ```

--- a/README.md
+++ b/README.md
@@ -1,8 +1,5 @@
 # Android Test Report Action
 
-[![Release](https://img.shields.io/github/release/asadmansr/android-test-report-action.svg)](https://github.com/asadmansr/android-test-report-action/releases)
-[![Marketplace](https://img.shields.io/badge/GitHub-Marketplace-orange.svg)](https://github.com/marketplace/actions/android-test-report-action)
-
 GitHub Action that prints Android test xml reports.
 
 ![action](./images/promo.png)
@@ -46,7 +43,9 @@ jobs:
         run: ./gradlew testDebugUnitTest
 
       - name: Android Test Report
-        uses: asadmansr/android-test-report-action@v1.2.0
+        uses: devapro/android-test-report-action@v1.3
+        with:
+          onlyFailed: true
         if: ${{ always() }} # IMPORTANT: run Android Test Report regardless
 ```
 #### Note
@@ -57,6 +56,8 @@ The workflow must contain the unit test job prior to running the Android Test Re
 ### Alternate
 
 If the basic usage fails to meet your requirement (running on MacOS machine or anything else), split the test and report into two jobs. The test job will run the tests and save the reports as artifacts. The report job will use the Android Test Report action to parse and print the results. Consider the following example below.
+
+*If you need to add to report only failed test set onlyFailed = true*
 
 ```yml
 jobs:
@@ -85,7 +86,9 @@ jobs:
           name: reports
 
       - name: Android Test Report
-        uses: asadmansr/android-test-report-action@v1.2.0
+        uses: devapro/android-test-report-action@v1.3
+        with:
+          onlyFailed: true
 ```
 
 <br>

--- a/action.yml
+++ b/action.yml
@@ -9,3 +9,9 @@ runs:
 branding:
   icon: 'file-text'
   color: 'red'
+  
+inputs:
+  onlyFailed:
+    description: 'Add to report only failed tests'
+    required: false
+    default: false

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -16,7 +16,7 @@ touch $log_file
 
 for i in `find . -name "TEST-*.xml" -type f`; do
     let num_files=num_files+1
-    python /usr/bin/extractReport.py "$i"
+    python /usr/bin/extractReport.py "$i" "$INPUT_ONLYFAILED"
     echo ''
 done
 

--- a/extractReport.py
+++ b/extractReport.py
@@ -9,7 +9,7 @@ def parseXML(xmlfile, onlyFailed):
     attributes = root.attrib
     
     for k,v in attributes.items():
-        if (onlyFailed != "true")
+        if (onlyFailed != "true"):
             cs = len(k)
             sp = 16-cs
             print(k.capitalize() + " "*sp + v)
@@ -46,7 +46,7 @@ def printFormatter(key, msg):
 def main():
     path = sys.argv[1]
     onlyFailed = sys.argv[2]
-    if (onlyFailed != "true")
+    if (onlyFailed != "true"):
         print(path + "\n")
     parseXML(path, onlyFailed)
 

--- a/extractReport.py
+++ b/extractReport.py
@@ -46,8 +46,8 @@ def printFormatter(key, msg):
 def main():
     path = sys.argv[1]
     onlyFailed = sys.argv[2]
-    print("Added only failed tests to report:" + onlyFailed + "\n")
-    print(path + "\n")
+    if (onlyFailed != "true")
+        print(path + "\n")
     parseXML(path, onlyFailed)
 
 if __name__ == "__main__":

--- a/extractReport.py
+++ b/extractReport.py
@@ -1,7 +1,7 @@
 import sys
 import xml.etree.ElementTree as ET
 
-def parseXML(xmlfile):
+def parseXML(xmlfile, onlyFailed):
     hasSeenFailure = False
     message = ""
     tree = ET.parse(xmlfile)
@@ -9,9 +9,10 @@ def parseXML(xmlfile):
     attributes = root.attrib
     
     for k,v in attributes.items():
-#         cs = len(k)
-#         sp = 16-cs
-#         print(k.capitalize() + " "*sp + v)
+        if (onlyFailed != "true")
+            cs = len(k)
+            sp = 16-cs
+            print(k.capitalize() + " "*sp + v)
         if ((k == "failures") and (int(v) > 0)) or ((k == "errors") and (int(v) > 0)):
             f = open("extractReport_status.log", "w")
             f.write("error")
@@ -44,8 +45,10 @@ def printFormatter(key, msg):
 
 def main():
     path = sys.argv[1]
+    onlyFailed = sys.argv[2]
+    print("Added only failed tests to report:" + onlyFailed + "\n")
     print(path + "\n")
-    parseXML(path)
+    parseXML(path, onlyFailed)
 
 if __name__ == "__main__":
     main()

--- a/extractReport.py
+++ b/extractReport.py
@@ -9,9 +9,9 @@ def parseXML(xmlfile):
     attributes = root.attrib
     
     for k,v in attributes.items():
-        cs = len(k)
-        sp = 16-cs
-        print(k.capitalize() + " "*sp + v)
+#         cs = len(k)
+#         sp = 16-cs
+#         print(k.capitalize() + " "*sp + v)
         if ((k == "failures") and (int(v) > 0)) or ((k == "errors") and (int(v) > 0)):
             f = open("extractReport_status.log", "w")
             f.write("error")


### PR DESCRIPTION
When you have a lot of tests and one of them is failed it is to difficult find in the report which one was broken.
I added a flag that prevents adding to report all test results. If this flag is true report will be contained only failed tests